### PR TITLE
Add setting for the template dir (allow overrides)

### DIFF
--- a/src/wagtailtrans/__init__.py
+++ b/src/wagtailtrans/__init__.py
@@ -1,1 +1,5 @@
+from os import path
+
 default_app_config = 'wagtailtrans.config.WagtailTransConfig'
+
+WAGTAILTRANS_TEMPLATE_DIR = path.join(path.dirname(__file__), 'templates')

--- a/tests/_sandbox/settings/base.py
+++ b/tests/_sandbox/settings/base.py
@@ -12,6 +12,8 @@
 """
 import os
 
+from wagtailtrans import WAGTAILTRANS_TEMPLATE_DIR
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -36,8 +38,6 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
 
-    'wagtailtrans',
-
     'wagtail.wagtailforms',
     'wagtail.wagtailredirects',
     'wagtail.wagtailembeds',
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     'wagtail.wagtailadmin',
     'wagtail.wagtailcore',
 
+    'wagtailtrans',
     'modelcluster',
     'taggit',
 
@@ -77,7 +78,9 @@ ROOT_URLCONF = 'tests._sandbox.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [
+            WAGTAILTRANS_TEMPLATE_DIR,
+        ],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [


### PR DESCRIPTION
With this setting, it doesn't matter where you put `wagtailtrans` in your `INSTALLED_APPS`, wagtail templates will be overridden by wagtailtrans.

```
from wagtailtrans import WAGTAILTRANS_TEMPLATE_DIR

TEMPLATES = {
    # ....
    'DIRS': [
        WAGTAILTRANS_TEMPLATE_DIR,
    ]
    # ....
}
```