### PR TITLE
Remove the include_self property of the get_translations method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+0.1.0b4
+-------
+
+ Backwards incompatible changes:
+
+  - Remove `include_self` attribute for `TranslatablePage.get_translations`
+
+
 0.0.1 (xxxx-xx-xx)
 ------------------
 

--- a/src/wagtailtrans/signals.py
+++ b/src/wagtailtrans/signals.py
@@ -43,7 +43,7 @@ def synchronize_deletions(sender, instance, **kwargs):
 
     """
     language = getattr(instance, 'language', False)
-    if language and not instance.canonical_page:
+    if language and not instance.is_canonical:
         instance.get_translations(only_live=False).delete()
 
 

--- a/src/wagtailtrans/signals.py
+++ b/src/wagtailtrans/signals.py
@@ -43,7 +43,7 @@ def synchronize_deletions(sender, instance, **kwargs):
 
     """
     language = getattr(instance, 'language', False)
-    if language and not instance.is_canonical:
+    if language and instance.is_canonical:
         instance.get_translations(only_live=False).delete()
 
 

--- a/src/wagtailtrans/urls/translations.py
+++ b/src/wagtailtrans/urls/translations.py
@@ -7,6 +7,6 @@ from wagtailtrans.views import translation
 app_name = 'wagtailtrans'
 
 urlpatterns = [
-    url(r'^(?P<page_pk>\w+)/add/(?P<language_code>\w+)/$',
+    url(r'^(?P<page_pk>\d+)/add/(?P<language_code>[^/]+)/$',
         translation.Add.as_view(), name='add'),
 ]

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -134,35 +134,30 @@ class TestTranslatablePage(object):
         nl_root.save()
 
         en_translations = [
-            p.specific for p in self.canonical_page.get_translations(
-                only_live=False)]
+            p.specific
+            for p in self.canonical_page.get_translations(only_live=False)]
         assert nl_root in en_translations
         assert fr_root in en_translations
         assert self.canonical_page not in en_translations
 
-        nl_translations = [p.specific for p in nl_root.get_translations(
-            only_live=False)]
+        nl_translations = [
+            p.specific for p in nl_root.get_translations(only_live=False)]
         assert self.canonical_page in nl_translations
         assert fr_root in nl_translations
         assert nl_root not in nl_translations
 
-        fr_translations = [p.specific for p in fr_root.get_translations(
-            only_live=False)]
+        fr_translations = [
+            p.specific for p in fr_root.get_translations(only_live=False)]
         assert self.canonical_page in fr_translations
         assert nl_root in fr_translations
         assert fr_root not in fr_translations
 
         # Some variations
-        en_translations = [p.specific for p in self.canonical_page.get_translations()]
+        en_translations = [
+            p.specific for p in self.canonical_page.get_translations()]
         assert nl_root in en_translations
         assert fr_root not in en_translations
         assert self.canonical_page not in en_translations
-
-        en_translations = [p.specific for p in self.canonical_page.get_translations(
-            include_self=True, only_live=False)]
-        assert nl_root in en_translations
-        assert fr_root in en_translations
-        assert self.canonical_page in en_translations
 
     def test_move_translated_pages(self, languages):
         """Test `move_translated_pages()`."""


### PR DESCRIPTION
The include_self property of TranslatablePage.get_translations isn't required for wagtailtrans to work. Previously we used it for the `translate into` button, since the object (page) itself isn't required in this list we can remove it.
