### PR TITLE
Force the parent language only when the parent has a language

### DIFF
--- a/src/wagtailtrans/edit_handlers.py
+++ b/src/wagtailtrans/edit_handlers.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.forms import HiddenInput
+from django.template import Context, Template
 from django.utils.safestring import mark_safe
 
 
@@ -10,7 +10,7 @@ class ReadOnlyWidget(forms.Select):
     """
     def __init__(self, text_display, *args, **kwargs):
         self.text_display = text_display
-        self.initial_widget = HiddenInput()
+        self.initial_widget = forms.HiddenInput()
         super(ReadOnlyWidget, self).__init__(*args, **kwargs)
 
     def render(self, *args, **kwargs):
@@ -18,3 +18,30 @@ class ReadOnlyWidget(forms.Select):
 
         return mark_safe("""<span class="hidden">%s</span>%s""" % (
             original_content, self.text_display))
+
+
+class CanonicalPageWidget(forms.Select):
+    """Add a link to the canonical page, for ease of use."""
+
+    def __init__(self, canonical_page, *args, **kwargs):
+        self.canonical_page = canonical_page
+        self.initial_widget = forms.HiddenInput()
+        super(CanonicalPageWidget, self).__init__(*args, **kwargs)
+
+    def render(self, *args, **kwargs):
+        original_content = self.initial_widget.render(*args, **kwargs)
+        template = Template("""
+            {% load i18n %}
+            <span class="hidden">{{ original_content }}</span>
+
+            {% if canonical_page %}
+                <a href="{% url 'wagtailadmin_pages:edit' canonical_page.id %}">{{ canonical_page.title }}</a>
+            {% else %}
+                {% trans "None" %}
+            {% endif %}
+        """)
+        return mark_safe(template.render(Context({
+            'canonical_page': self.canonical_page,
+            'original_content': original_content,
+        })))
+

--- a/src/wagtailtrans/edit_handlers.py
+++ b/src/wagtailtrans/edit_handlers.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from django import forms
 from django.template import Context, Template
 from django.utils.safestring import mark_safe

--- a/src/wagtailtrans/models.py
+++ b/src/wagtailtrans/models.py
@@ -232,30 +232,6 @@ class TranslatablePage(Page):
 
         return new_page
 
-    # def force_parent_language(self, parent=None):
-    #     """Set Page instance language to the parent language.
-    #
-    #     TODO: This used to be called from the `save()` method, but
-    #     afterwards wasn't saved. Saving it would lead to recursion
-    #     errors especially in combination with the defined signal handlers.
-    #     We'll have to see if we can perform `force_parent_language` upon
-    #     save (either by override `save()` or by using
-    #     `pre_save` or `post_save` signals)
-    #
-    #     :param parent: Parent page of self
-    #     :return: Language instance
-    #
-    #     """
-    #     if not parent:
-    #         parent = self.get_parent()
-    #
-    #     parent = parent.specific
-    #     if hasattr(parent, 'language'):
-    #         if self.language != parent.language:
-    #             self.language = parent.language
-    #
-    #     return self.language
-
     @cached_property
     def has_translations(self):
         return self.translations.exists()

--- a/src/wagtailtrans/models.py
+++ b/src/wagtailtrans/models.py
@@ -17,7 +17,7 @@ from wagtail.wagtailadmin.forms import (
     WagtailAdminModelForm, WagtailAdminPageForm)
 from wagtail.wagtailcore.models import Page
 
-from .edit_handlers import ReadOnlyWidget
+from .edit_handlers import ReadOnlyWidget, CanonicalPageWidget
 from .managers import LanguageManager
 from .permissions import TranslatableUserPagePermissionsProxy
 from .utils.conf import get_wagtailtrans_setting
@@ -65,11 +65,8 @@ class AdminTranslatablePageForm(WagtailAdminPageForm):
     def __init__(self, *args, **kwargs):
         super(AdminTranslatablePageForm, self).__init__(*args, **kwargs)
 
-        canonical_page_text = _("None")
-        if self.instance.canonical_page:
-            canonical_page_text = self.instance.canonical_page.title
-        self.fields['canonical_page'].widget = ReadOnlyWidget(
-            text_display=canonical_page_text)
+        self.fields['canonical_page'].widget = CanonicalPageWidget(
+            canonical_page=self.instance.canonical_page)
 
         language_display = Language.objects.filter(
             pk=self.initial['language']).first()
@@ -78,11 +75,6 @@ class AdminTranslatablePageForm(WagtailAdminPageForm):
 
         self.fields['language'].widget = ReadOnlyWidget(
             text_display=language_display if language_display else '')
-
-    def clean_language(self):
-        return (
-            self.instance.force_parent_language(self.parent_page) or
-            Language.objects.default())
 
 
 def _language_default():
@@ -240,29 +232,29 @@ class TranslatablePage(Page):
 
         return new_page
 
-    def force_parent_language(self, parent=None):
-        """Set Page instance language to the parent language.
-
-        TODO: This used to be called from the `save()` method, but
-        afterwards wasn't saved. Saving it would lead to recursion
-        errors especially in combination with the defined signal handlers.
-        We'll have to see if we can perform `force_parent_language` upon
-        save (either by override `save()` or by using
-        `pre_save` or `post_save` signals)
-
-        :param parent: Parent page of self
-        :return: Language instance
-
-        """
-        if not parent:
-            parent = self.get_parent()
-
-        parent = parent.specific
-        if hasattr(parent, 'language'):
-            if self.language != parent.language:
-                self.language = parent.language
-
-        return self.language
+    # def force_parent_language(self, parent=None):
+    #     """Set Page instance language to the parent language.
+    #
+    #     TODO: This used to be called from the `save()` method, but
+    #     afterwards wasn't saved. Saving it would lead to recursion
+    #     errors especially in combination with the defined signal handlers.
+    #     We'll have to see if we can perform `force_parent_language` upon
+    #     save (either by override `save()` or by using
+    #     `pre_save` or `post_save` signals)
+    #
+    #     :param parent: Parent page of self
+    #     :return: Language instance
+    #
+    #     """
+    #     if not parent:
+    #         parent = self.get_parent()
+    #
+    #     parent = parent.specific
+    #     if hasattr(parent, 'language'):
+    #         if self.language != parent.language:
+    #             self.language = parent.language
+    #
+    #     return self.language
 
     @cached_property
     def has_translations(self):

--- a/src/wagtailtrans/models.py
+++ b/src/wagtailtrans/models.py
@@ -261,9 +261,7 @@ class TranslatablePage(Page):
         if hasattr(parent, 'language'):
             if self.language != parent.language:
                 self.language = parent.language
-        elif get_wagtailtrans_setting('LANGUAGES_PER_SITE'):
-            site = parent.get_site()
-            self.language = site.sitelanguages.default_language
+
         return self.language
 
     @cached_property

--- a/src/wagtailtrans/signals.py
+++ b/src/wagtailtrans/signals.py
@@ -148,7 +148,8 @@ def force_parent_language(**kwargs):
         site = parent.sites_rooted_here.first()
         if site:
             lang_settings = SiteLanguages.for_site(site)
-            page.language = lang_settings.default_language or Language.objects.default()
+            page.language = (
+                lang_settings.default_language or Language.objects.default())
 
 
 def register_signal_handlers():

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -102,23 +102,6 @@ class TestTranslatablePage(object):
         self.canonical_page.create_translation(language_nl, copy_fields=True)
         assert self.canonical_page.has_translation(language_nl)
 
-    def test_force_parent_language(self, languages):
-        """Test `force_parent_language()`."""
-        en = languages.get(code='en')
-        nl = languages.get(code='nl')
-        nl_page = self.canonical_page.create_translation(
-            language=nl, copy_fields=True)
-
-        subpage = TranslatablePageFactory.build(
-            language=en, title='subpage in NL tree')
-        assert subpage.language == en
-
-        # After adding the English page to a Dutch tree,
-        # it should have been forced into Dutch (such a wonderful world)
-        nl_page.add_child(instance=subpage)
-        subpage.force_parent_language()
-        assert subpage.language == nl
-
     def test_get_translations(self, languages):
         """Test `get_translations()`."""
         nl = languages.get(code='nl')


### PR DESCRIPTION
When publishing pages with the setting `LANGUAGES_PER_SITE=True` it always forced the page to become the `default_language` for that site.