### PR TITLE
Fix move language per site

### DIFF
--- a/src/wagtailtrans/models.py
+++ b/src/wagtailtrans/models.py
@@ -124,10 +124,17 @@ class TranslatablePage(Page):
 
         """
         super(TranslatablePage, self).move(target, pos)
+
+        if get_wagtailtrans_setting('LANGUAGES_PER_SITE'):
+            site = self.get_site()
+            lang_settings = SiteLanguages.for_site(site)
+            default_lang = lang_settings.default_language
+        else:
+            default_lang = _language_default()
         if (
             not suppress_sync and
             get_wagtailtrans_setting('SYNC_TREE') and
-            self.language.is_default
+            self.language == default_lang
         ):
             self.move_translated_pages(canonical_target=target, pos=pos)
 

--- a/src/wagtailtrans/models.py
+++ b/src/wagtailtrans/models.py
@@ -128,13 +128,13 @@ class TranslatablePage(Page):
         if get_wagtailtrans_setting('LANGUAGES_PER_SITE'):
             site = self.get_site()
             lang_settings = SiteLanguages.for_site(site)
-            default_lang = lang_settings.default_language
+            is_default = lang_settings.default_language == self.language
         else:
-            default_lang = _language_default()
+            is_default = self.language.is_default
         if (
             not suppress_sync and
             get_wagtailtrans_setting('SYNC_TREE') and
-            self.language == default_lang
+            is_default
         ):
             self.move_translated_pages(canonical_target=target, pos=pos)
 


### PR DESCRIPTION
A fix for when LANGUAGE_PER_SITE is enabled and you move a page. (did not move pages with a default language other than the database default language)