### PR TITLE
Wagtail 16 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,41 @@ sudo: false
 language: python
 matrix:
   include:
-    - env: TOXENV=py27-dj18
+    - env: TOXENV=py27-dj18-wt16
       python: 2.7
-    - env: TOXENV=py34-dj18
+    - env: TOXENV=py34-dj18-wt16
       python: 3.4
-    - env: TOXENV=py35-dj18
+    - env: TOXENV=py35-dj18-wt16
       python: 3.5
-    - env: TOXENV=py27-dj19
+    - env: TOXENV=py27-dj19-wt16
       python: 2.7
-    - env: TOXENV=py34-dj19
+    - env: TOXENV=py34-dj19-wt16
       python: 3.4
-    - env: TOXENV=py35-dj19
+    - env: TOXENV=py35-dj19-wt16
       python: 3.5
-    - env: TOXENV=py27-dj110
+    - env: TOXENV=py27-dj110-wt16
       python: 2.7
-    - env: TOXENV=py34-dj110
+    - env: TOXENV=py34-dj110-wt16
       python: 3.4
-    - env: TOXENV=py35-dj110
+    - env: TOXENV=py35-dj110-wt16
+      python: 3.5
+    - env: TOXENV=py27-dj18-wt17
+      python: 2.7
+    - env: TOXENV=py34-dj18-wt17
+      python: 3.4
+    - env: TOXENV=py35-dj18-wt17
+      python: 3.5
+    - env: TOXENV=py27-dj19-wt17
+      python: 2.7
+    - env: TOXENV=py34-dj19-wt17
+      python: 3.4
+    - env: TOXENV=py35-dj19-wt17
+      python: 3.5
+    - env: TOXENV=py27-dj110-wt17
+      python: 2.7
+    - env: TOXENV=py34-dj110-wt17
+      python: 3.4
+    - env: TOXENV=py35-dj110-wt17
       python: 3.5
     - env: TOXENV=flake8
       python: 2.7

--- a/README.rst
+++ b/README.rst
@@ -18,37 +18,43 @@
 Wagtail multilanguage module
 ============================
 
-Features
-========
+Support multiple languages for your Wagtail site.
 
-* Support multiple languages for your Wagtail site
+Requirements
+------------
+
+ - Python 2.7+
+ - Django 1.8+
+ - Wagtail 1.6+
+
 
 Documentation
-=============
+-------------
 
-http://wagtailtrans.readthedocs.io/
+Project documentation can be found on [Read the docs](http://wagtailtrans.readthedocs.io/)
+
 
 Getting started
-===============
+---------------
 
-1. To install wagtailtrans, run this command in your terminal:
-
-.. code-block:: console
-    ``pip install wagtailtrans``
-
-2. Add ``wagtailtrans`` to your INSTALLED_APPS
-
-3. Perform a migration
+ 1. To install wagtailtrans, run this command in your terminal:
 
 .. code-block:: console
-    ``python manage.py migrate wagtailtrans``
+    pip install wagtailtrans
+
+ 2. Add ``wagtailtrans`` to your INSTALLED_APPS
+ 3. Perform a migration
+
+.. code-block:: console
+    python manage.py migrate wagtailtrans``
 
 You're set!
 
+
 Settings
-========
+--------
 
-The settings ``WAGTAILTRANS_SYNC_TREE`` can be used to configure the module to keep your language trees synchronized or not.
-This is set to ``True`` by default.
+Wagtailtrans can be configured to suit your needs, following settings are available:
 
-Use ``WAGTAILTRANS_SYNC_TREE = False`` to disable sync and have free flowing trees.
+ - `WAGTAILTRANS_SYNC_TREE` _(default: True)_ configure the module to keep your language trees sychronized.
+ - `WAGTAILTRANS_LANGUAGES_PER_SITE` _(default: False)_ allow different languages per site (multi site setup)

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,5 @@ setup(
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Topic :: Internet :: WWW/HTTP :: Site Management',
-    ],
-    install_requires=[
-        'wagtail>=1.6',
     ]
 )

--- a/src/wagtailtrans/migrations/0004_sitelanguages.py
+++ b/src/wagtailtrans/migrations/0004_sitelanguages.py
@@ -9,7 +9,7 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('wagtailcore', '0030_index_on_pagerevision_created_at'),
+        ('wagtailcore', '0029_unicode_slugfield_dj19'),
         ('wagtailtrans', '0003_auto_20161121_1211'),
     ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{27,34,35}-dj{18,19,110},flake8
+envlist=py{27,34,35}-dj{18,19,110}-wt{16,17},flake8
 
 [testenv]
 basepython =
@@ -12,6 +12,8 @@ deps=
     dj18: django>=1.8,<1.9
     dj19: django>=1.9,<1.10
     dj110: django>=1.10,<1.11
+    wt16: wagtail>=1.6,<1.7
+    wt17: wagtail>=1.7,<1.8
     coverage
     factory-boy
     flake8


### PR DESCRIPTION
I've fixed a minor issue, where migrating with a wagtail 1.6 installation wouldn't work, because we were pointing to a newer migration than available in wagtail 1.6

Also updated the tox.ini and travis config to test against wagtail 1.6 and wagtail 1.7