### PR TITLE
Add specific in the AdminTranslatablePageForm to fix issue 54

### DIFF
--- a/src/wagtailtrans/models.py
+++ b/src/wagtailtrans/models.py
@@ -71,7 +71,7 @@ class AdminTranslatablePageForm(WagtailAdminPageForm):
 
         language_display = Language.objects.filter(
             pk=self.initial['language']).first()
-        if self.instance.is_canonical and language_display:
+        if self.instance.specific.is_canonical and language_display:
             language_display = "{} - {}".format(language_display, "canonical")
 
         self.fields['language'].widget = ReadOnlyWidget(

--- a/src/wagtailtrans/models.py
+++ b/src/wagtailtrans/models.py
@@ -67,7 +67,7 @@ class AdminTranslatablePageForm(WagtailAdminPageForm):
         super(AdminTranslatablePageForm, self).__init__(*args, **kwargs)
 
         self.fields['canonical_page'].widget = CanonicalPageWidget(
-            canonical_page=self.instance.canonical_page)
+            canonical_page=self.instance.specific.canonical_page)
 
         language_display = Language.objects.filter(
             pk=self.initial['language']).first()


### PR DESCRIPTION
As described in issue #54 sometimes a page instance can show up as not a `TranslatablePage` instance, this should fix that.