### PR TITLE
Document middleware dependency

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -43,7 +43,12 @@ Installation
 
 .. note::
 
-    Keep in mind ``wagtailtrans.middleware.TranslationMiddleware`` is a replacement for ``django.middleware.locale.LocaleMiddleware``. Also, it relies on ``wagtail.wagtailcore.middleware.SiteMiddleware``, which should always be mentioned first.
+    Keep in mind ``wagtailtrans.middleware.TranslationMiddleware`` is a replacement for ``django.middleware.locale.LocaleMiddleware``.
+
+.. note::
+
+    It relies on ``wagtail.wagtailcore.middleware.SiteMiddleware``, which should come before it.
+    See http://docs.wagtail.io/en/v1.8/getting_started/integrating_into_django.html#settings for more information.
 
 
 4. Optionally, add ``WAGTAILTRANS_TEMPLATE_DIR`` to your ``TEMPLATES[0]['DIRS']``

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -35,6 +35,7 @@ Installation
     MIDDLEWARE_CLASSES = [
         # ...
         'django.contrib.sessions.middleware.SessionMiddleware',
+        'wagtail.wagtailcore.middleware.SiteMiddleware',
         'wagtailtrans.middleware.TranslationMiddleware',
         'django.middleware.common.CommonMiddleware',
         # ...
@@ -42,7 +43,7 @@ Installation
 
 .. note::
 
-    Keep in mind ``wagtailtrans.middleware.TranslationMiddleware`` is a replacement for ``django.middleware.locale.LocaleMiddleware``.
+    Keep in mind ``wagtailtrans.middleware.TranslationMiddleware`` is a replacement for ``django.middleware.locale.LocaleMiddleware``. Also, it relies on ``wagtail.wagtailcore.middleware.SiteMiddleware``, which should always be mentioned first.
 
 
 4. Optionally, add ``WAGTAILTRANS_TEMPLATE_DIR`` to your ``TEMPLATES[0]['DIRS']``


### PR DESCRIPTION
wagtailtrans.middleware.TranslationMiddleware tries to access request.site,
which is only available if wagtail.wagtailcore.middleware.SiteMiddleware is
loaded first. Since django will happily and silently let the AttributeError
pass, this should really be documented

### Thanks for contributing!

Please make sure all the tests pass, before creating a pull-request.
