### PR TITLE
Switch to assignment tags for django 1.8 compatibility

### DIFF
--- a/src/wagtailtrans/templatetags/translations_wagtail_admin.py
+++ b/src/wagtailtrans/templatetags/translations_wagtail_admin.py
@@ -1,3 +1,4 @@
+import django
 from django import template
 
 from wagtailtrans.models import TranslatablePage
@@ -6,7 +7,13 @@ from wagtailtrans.utils.conf import get_wagtailtrans_setting
 register = template.Library()
 
 
-@register.assignment_tag
+if django.VERSION >= (1, 9):
+    assignment_tag = register.simple_tag
+else:
+    assignment_tag = register.assignment_tag
+
+
+@assignment_tag
 def get_canonical_pages_for_delete(page):
     """Get the translations made for this page
 
@@ -23,6 +30,6 @@ def get_canonical_pages_for_delete(page):
     return False
 
 
-@register.assignment_tag
+@assignment_tag
 def languages_per_site_enabled():
     return get_wagtailtrans_setting('LANGUAGES_PER_SITE')

--- a/src/wagtailtrans/templatetags/translations_wagtail_admin.py
+++ b/src/wagtailtrans/templatetags/translations_wagtail_admin.py
@@ -6,7 +6,7 @@ from wagtailtrans.utils.conf import get_wagtailtrans_setting
 register = template.Library()
 
 
-@register.simple_tag
+@register.assignment_tag
 def get_canonical_pages_for_delete(page):
     """Get the translations made for this page
 
@@ -23,6 +23,6 @@ def get_canonical_pages_for_delete(page):
     return False
 
 
-@register.simple_tag
+@register.assignment_tag
 def languages_per_site_enabled():
     return get_wagtailtrans_setting('LANGUAGES_PER_SITE')


### PR DESCRIPTION
This switches to assignment tags to make code compatible with Django 1.8
@mikedingjan Needs review, this does imply using the slightly deprecated assignment tags..
