### PR TITLE
Update middleware to prevent errors on empty database

### DIFF
--- a/src/wagtailtrans/middleware.py
+++ b/src/wagtailtrans/middleware.py
@@ -34,8 +34,8 @@ class TranslationMiddleware(MiddlewareMixin):
                 if active_language is not None:
                     break
 
-        if active_language is None and (
-            get_wagtailtrans_setting('LANGUAGES_PER_SITE') and request.site):
+        lang_per_site = get_wagtailtrans_setting('LANGUAGES_PER_SITE')
+        if active_language is None and lang_per_site and request.site:
             site_languages = SiteLanguages.for_site(request.site)
             if site_languages.default_language:
                 active_language = site_languages.default_language.code

--- a/src/wagtailtrans/middleware.py
+++ b/src/wagtailtrans/middleware.py
@@ -34,7 +34,8 @@ class TranslationMiddleware(MiddlewareMixin):
                 if active_language is not None:
                     break
 
-        if active_language is None and get_wagtailtrans_setting('LANGUAGES_PER_SITE') and request.site:
+        if active_language is None and (
+            get_wagtailtrans_setting('LANGUAGES_PER_SITE') and request.site):
             site_languages = SiteLanguages.for_site(request.site)
             if site_languages.default_language:
                 active_language = site_languages.default_language.code

--- a/src/wagtailtrans/middleware.py
+++ b/src/wagtailtrans/middleware.py
@@ -34,16 +34,17 @@ class TranslationMiddleware(MiddlewareMixin):
                 if active_language is not None:
                     break
 
-        if active_language is None:
-            if get_wagtailtrans_setting('LANGUAGES_PER_SITE') and request.site:
-                site_languages = SiteLanguages.for_site(request.site)
+        if active_language is None and get_wagtailtrans_setting('LANGUAGES_PER_SITE') and request.site:
+            site_languages = SiteLanguages.for_site(request.site)
+            if site_languages.default_language:
                 active_language = site_languages.default_language.code
+
+        if active_language is None:
+            default_language = Language.objects.default()
+            if default_language:
+                active_language = default_language.code
             else:
-                default_language = Language.objects.default()
-                if default_language:
-                    active_language = default_language.code
-                else:
-                    active_language = settings.LANGUAGE_CODE
+                active_language = settings.LANGUAGE_CODE
 
         translation.activate(active_language)
         request.LANGUAGE_CODE = active_language

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -87,6 +87,16 @@ class TestTranslationMiddleware(object):
 
         assert request.LANGUAGE_CODE == 'es'
 
+
+    def test_request_no_languages(self, rf):
+        Language.objects.all().delete()
+        request = rf.get('/')
+
+        with override_settings(LANGUAGE_CODE='en'):
+            TranslationMiddleware().process_request(request)
+
+        assert request.LANGUAGE_CODE == 'en'
+
     def test_response(self, rf):
         request = rf.get('/nl/random/page/')
         TranslationMiddleware().process_request(request)


### PR DESCRIPTION
This will fix issues when starting a new project which doesn't have any ``Language`` objects in it's database.