### PR TITLE
Less spammy coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,20 @@ script:
   - tox -e $TOXENV
 services:
   - postgresql
-after_success: coveralls
+after_script:
+  - |
+
+      declare exitCode
+
+
+      # -- [1] -------------------------------------------------------
+
+      curl -sSL https://raw.githubusercontent.com/alrra/travis-after-all/1.4.4/lib/travis-after-all.js | node
+      exitCode=$?
+
+
+      # -- [2] -------------------------------------------------------
+
+      if [ $exitCode -eq 0 ]; then
+        coveralls
+      fi


### PR DESCRIPTION
Right now the coveralls bot has spammy behaviour in Pull Requests. Unfortunately the `after_success` gets executed after every successful step in the build matrix. At some point in time an `after_all` command will be available. See: https://github.com/travis-ci/travis-ci/issues/929

For now I have added a workaround: https://github.com/alrra/travis-after-all