### PR TITLE
Drop wagtail 1.6, add tests for wagtail 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,6 @@ language: python
 cache: pip
 matrix:
   include:
-    - env: TOXENV=py27-dj18-wt16
-      python: 2.7
-    - env: TOXENV=py34-dj18-wt16
-      python: 3.4
-    - env: TOXENV=py35-dj18-wt16
-      python: 3.5
-    - env: TOXENV=py27-dj19-wt16
-      python: 2.7
-    - env: TOXENV=py34-dj19-wt16
-      python: 3.4
-    - env: TOXENV=py35-dj19-wt16
-      python: 3.5
-    - env: TOXENV=py27-dj110-wt16
-      python: 2.7
-    - env: TOXENV=py34-dj110-wt16
-      python: 3.4
-    - env: TOXENV=py35-dj110-wt16
-      python: 3.5
     - env: TOXENV=py27-dj18-wt17
       python: 2.7
     - env: TOXENV=py34-dj18-wt17
@@ -56,6 +38,24 @@ matrix:
     - env: TOXENV=py34-dj110-wt18
       python: 3.4
     - env: TOXENV=py35-dj110-wt18
+      python: 3.5
+    - env: TOXENV=py27-dj18-wt19
+      python: 2.7
+    - env: TOXENV=py34-dj18-wt19
+      python: 3.4
+    - env: TOXENV=py35-dj18-wt19
+      python: 3.5
+    - env: TOXENV=py27-dj19-wt19
+      python: 2.7
+    - env: TOXENV=py34-dj19-wt19
+      python: 3.4
+    - env: TOXENV=py35-dj19-wt19
+      python: 3.5
+    - env: TOXENV=py27-dj110-wt19
+      python: 2.7
+    - env: TOXENV=py34-dj110-wt19
+      python: 3.4
+    - env: TOXENV=py35-dj110-wt19
       python: 3.5
     - env: TOXENV=flake8
       python: 2.7

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Requirements
 
  - Python 2.7+
  - Django 1.8+
- - Wagtail 1.6+
+ - Wagtail 1.7+
 
 
 Getting started

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{27,34,35}-dj{18,19,110}-wt{16,17,18},flake8
+envlist=py{27,34,35}-dj{18,19,110}-wt{17,18,19},flake8
 
 [testenv]
 basepython =
@@ -12,9 +12,9 @@ deps=
     dj18: django>=1.8,<1.9
     dj19: django>=1.9,<1.10
     dj110: django>=1.10,<1.11
-    wt16: wagtail>=1.6,<1.7
     wt17: wagtail>=1.7,<1.8
     wt18: wagtail>=1.8,<1.9
+    wt19: wagtail>=1.9,<1.10
     coverage
     factory-boy
     flake8


### PR DESCRIPTION
As agreed on, we're only supporting the current and 2 previous versions of wagtail. This PR drops the tests for wagtail 1.6 and add tests for wagtail 1.9