### PR TITLE
Update tox and travis test matrix in-line with Wagtail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,35 +3,11 @@ language: python
 cache: pip
 matrix:
   include:
-    - env: TOXENV=py27-dj18-wt17
-      python: 2.7
-    - env: TOXENV=py34-dj18-wt17
-      python: 3.4
-    - env: TOXENV=py35-dj18-wt17
-      python: 3.5
-    - env: TOXENV=py27-dj19-wt17
-      python: 2.7
-    - env: TOXENV=py34-dj19-wt17
-      python: 3.4
-    - env: TOXENV=py35-dj19-wt17
-      python: 3.5
-    - env: TOXENV=py27-dj110-wt17
-      python: 2.7
-    - env: TOXENV=py34-dj110-wt17
-      python: 3.4
-    - env: TOXENV=py35-dj110-wt17
-      python: 3.5
     - env: TOXENV=py27-dj18-wt18
       python: 2.7
     - env: TOXENV=py34-dj18-wt18
       python: 3.4
     - env: TOXENV=py35-dj18-wt18
-      python: 3.5
-    - env: TOXENV=py27-dj19-wt18
-      python: 2.7
-    - env: TOXENV=py34-dj19-wt18
-      python: 3.4
-    - env: TOXENV=py35-dj19-wt18
       python: 3.5
     - env: TOXENV=py27-dj110-wt18
       python: 2.7
@@ -45,18 +21,32 @@ matrix:
       python: 3.4
     - env: TOXENV=py35-dj18-wt19
       python: 3.5
-    - env: TOXENV=py27-dj19-wt19
-      python: 2.7
-    - env: TOXENV=py34-dj19-wt19
-      python: 3.4
-    - env: TOXENV=py35-dj19-wt19
-      python: 3.5
     - env: TOXENV=py27-dj110-wt19
       python: 2.7
     - env: TOXENV=py34-dj110-wt19
       python: 3.4
     - env: TOXENV=py35-dj110-wt19
       python: 3.5
+    - env: TOXENV=py27-dj18-wt110
+      python: 2.7
+    - env: TOXENV=py34-dj18-wt110
+      python: 3.4
+    - env: TOXENV=py35-dj18-wt110
+      python: 3.5
+    - env: TOXENV=py27-dj110-wt110
+      python: 2.7
+    - env: TOXENV=py34-dj110-wt110
+      python: 3.4
+    - env: TOXENV=py35-dj110-wt110
+      python: 3.5
+    - env: TOXENV=py27-dj111-wt110
+      python: 2.7
+    - env: TOXENV=py34-dj111-wt110
+      python: 3.4
+    - env: TOXENV=py35-dj111-wt110
+      python: 3.5
+    - env: TOXENV=py36-dj111-wt110
+      python: 3.6
     - env: TOXENV=flake8
       python: 2.7
 install:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ Changelog
 -----------------
 
  - Add ``include_self=False`` kwarg to ``TranslatablePage.get_translations()`` to have the page return itself as well
+ - Add language selector template tags
+ - Update ``Language`` management to make use of ``wagtail.contrib.modeladmin``
+ - Update ``Tox`` and ``Travis`` test matrix to include ``Wagtail 1.10`` support
 
 
 0.1.2 (15-03-2017)

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Requirements
 
  - Python 2.7+
  - Django 1.8+
- - Wagtail 1.7+
+ - Wagtail 1.8+
 
 
 Getting started

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,8 +5,10 @@ django_find_project = true
 
 [flake8]
 ignore=E731
+max-complexity = 10
+max-line-length = 80
 exclude=
-    src/**/migrations/*.py
+    **/migrations/*.py
 
 [bdist_wheel]
 universal = 1

--- a/tests/_sandbox/settings/base.py
+++ b/tests/_sandbox/settings/base.py
@@ -33,7 +33,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 # Application definition
 INSTALLED_APPS = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,38 +1,41 @@
 [tox]
-envlist=py{27,34,35}-dj{18,19,110}-wt{17,18,19},flake8
+skipsdist = True
+usedevelop = True
+envlist =
+    py{27,34,35}-dj{18,110}-wt{18,19,110},
+    py{27,34,35,36}-dj111-wt110,
+    flake8
 
 [testenv]
 basepython =
     py27: python2.7
     py34: python3.4
     py35: python3.5
-commands=
+    py36: python3.6
+install_command = pip install -e . -U {opts} {packages}
+commands =
     py.test --cov=wagtailtrans --cov-report=xml tests/
-deps=
+deps =
     dj18: django>=1.8,<1.9
-    dj19: django>=1.9,<1.10
     dj110: django>=1.10,<1.11
+    dj111: django>=1.11,<2.0
     wt17: wagtail>=1.7,<1.8
     wt18: wagtail>=1.8,<1.9
     wt19: wagtail>=1.9,<1.10
+    wt110: wagtail>=1.10rc1,<1.11
     coverage
     factory-boy
-    flake8
     pytest
     pytest-cov
     pytest-django
     psycopg2
-setenv=
+setenv =
     DJANGO_SETTINGS_MODULE=tests._sandbox.settings
 
 [testenv:flake8]
-basepython=python2.7
-skip_install=true
-max-line-length = 80
-max-complexity = 10
-commands=
+basepython = python2.7
+skip_install = True
+commands =
     flake8 src
-exclude=
-    */migrations/*
-deps=
+deps =
     flake8


### PR DESCRIPTION
This PR will:
  - Add support for Python 3.6, Wagtail 1.10 and Django 1.11
  - Remove support for Wagtail 1.7 and Django 1.9

Fixes: #82 and #84 