### PR TITLE
Cleanup templatetag for language_per_site_enable

### DIFF
--- a/src/wagtailtrans/templatetags/translations_wagtail_admin.py
+++ b/src/wagtailtrans/templatetags/translations_wagtail_admin.py
@@ -28,8 +28,3 @@ def get_canonical_pages_for_delete(page):
     ):
         return TranslatablePage.objects.filter(canonical_page=page)
     return False
-
-
-@assignment_tag
-def languages_per_site_enabled():
-    return get_wagtailtrans_setting('LANGUAGES_PER_SITE')


### PR DESCRIPTION
Cleaned up the templatetag for language_per_site_enabled within our wagtailadmin tags.
Whilst prepping some additional templatetag tests it turned out this templatetag is not used anywhere. Or maybe I'm missing something obvious 😉 