### PR TITLE
Fix bug which when creating new language if there are non translatable languages in the tree

### DIFF
--- a/src/wagtailtrans/signals.py
+++ b/src/wagtailtrans/signals.py
@@ -76,8 +76,12 @@ def create_new_language_tree_for_site(site, language):
         return
     descendants = canonical_home_page.get_descendants(inclusive=True)
     for child_page in descendants:
-        if not child_page.specific.has_translation(language):
-            child_page.specific.create_translation(language, copy_fields=True)
+        child_page = child_page.specific
+        if (
+            hasattr(child_page, 'language') and
+            not child_page.has_translation(language)
+        ):
+            child_page.create_translation(language, copy_fields=True)
 
 
 def create_new_language_tree(sender, instance, **kwargs):

--- a/src/wagtailtrans/sites.py
+++ b/src/wagtailtrans/sites.py
@@ -1,5 +1,5 @@
 from .conf import get_wagtailtrans_setting
-from .models import SiteLanguages, Language
+from .models import Language, SiteLanguages
 
 
 def get_languages_for_site(site):

--- a/tests/factories/language.py
+++ b/tests/factories/language.py
@@ -12,4 +12,3 @@ class LanguageFactory(factory.DjangoModelFactory):
     class Meta:
         model = models.Language
         django_get_or_create = ['code']
-

--- a/tests/factories/pages.py
+++ b/tests/factories/pages.py
@@ -3,9 +3,10 @@ from wagtail.wagtailcore.models import Page
 from wagtail.wagtailimages.tests.utils import (
     get_image_model, get_test_image_file)
 
+from wagtailtrans import models
+
 from tests._sandbox.pages.models import HomePage
 from tests.factories import language
-from wagtailtrans import models
 
 
 class TranslatableSiteRootFactory(factory.DjangoModelFactory):
@@ -65,3 +66,11 @@ class HomePageFactory(TranslatablePageFactory):
             if not getattr(obj, part):
                 setattr(obj, part, "{} {}".format(part, obj.language.code))
         return obj
+
+
+class WagtailPageFactory(factory.DjangoModelFactory):
+    depth = 0
+    title = 'root'
+
+    class Meta:
+        model = Page

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -1,13 +1,11 @@
 import pytest
-
 from django.test import override_settings
 
+from tests.factories import language, sites
+from tests.factories.pages import HomePageFactory, WagtailPageFactory
 from wagtailtrans import signals
 from wagtailtrans.models import Language, SiteLanguages, TranslatablePage
 from wagtailtrans.signals import register_signal_handlers
-
-from tests.factories import language, sites
-from tests.factories.pages import HomePageFactory
 
 
 @pytest.mark.django_db

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -36,6 +36,17 @@ class TestSignals(object):
         assert not TranslatablePage.objects.filter(
             language=lang, canonical_page=self.last_page).exists()
 
+    @override_settings(WAGTAILTRANS_SYNC_TREE=True)
+    def test_do_not_copy_non_translatable_page(self):
+        page = WagtailPageFactory.build(title='test')
+        self.last_page.add_child(instance=page)
+
+        lang = language.LanguageFactory(
+            is_default=False, code='fr', position=2)
+
+        assert TranslatablePage.objects.filter(
+            language=lang, canonical_page=self.last_page).exists()
+
 
 @pytest.mark.django_db
 class TestSignalsLanguagesPerSite(object):

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -1,11 +1,12 @@
 import pytest
 from django.test import override_settings
 
-from tests.factories import language, sites
-from tests.factories.pages import HomePageFactory, WagtailPageFactory
 from wagtailtrans import signals
 from wagtailtrans.models import Language, SiteLanguages, TranslatablePage
 from wagtailtrans.signals import register_signal_handlers
+
+from tests.factories import language, sites
+from tests.factories.pages import HomePageFactory, WagtailPageFactory
 
 
 @pytest.mark.django_db

--- a/tests/unit/test_sites.py
+++ b/tests/unit/test_sites.py
@@ -20,4 +20,3 @@ def test_get_languages_for_site(languages):
     with override_settings(WAGTAILTRANS_LANGUAGES_PER_SITE=True):
         language_codes = [l.code for l in sites.get_languages_for_site(site)]
         assert language_codes == ['en', 'es', 'fr']
-


### PR DESCRIPTION
fix a bug where non translatable pages will crash the signal triggered when creating a new language

