### PR TITLE
fix issue with WAGTAILTRANS_LANGUAGES_PER_SITE SETTING

### DIFF
--- a/src/wagtailtrans/models.py
+++ b/src/wagtailtrans/models.py
@@ -142,7 +142,7 @@ def _language_default():
 
 class TranslatablePage(Page):
 
-    #: Defined with a uniqe name, to prevent field clashes..
+    #: Defined with a unique name, to prevent field clashes..
     translatable_page_ptr = models.OneToOneField(
         Page, parent_link=True, related_name='+', on_delete=models.CASCADE)
     canonical_page = models.ForeignKey(

--- a/src/wagtailtrans/models.py
+++ b/src/wagtailtrans/models.py
@@ -50,9 +50,6 @@ class WagtailAdminLanguageForm(WagtailAdminModelForm):
         sorted_choices = sorted(self.fields['code'].choices, key=itemgetter(1))
         self.fields['code'].choices = sorted_choices
 
-        if get_wagtailtrans_setting('LANGUAGES_PER_SITE'):
-            del self.fields['is_default']
-
     def clean_is_default(self):
         is_default = self.cleaned_data['is_default']
         default_lang = Language.objects.default()

--- a/tests/_sandbox/settings/base.py
+++ b/tests/_sandbox/settings/base.py
@@ -12,12 +12,8 @@
 """
 import os
 
-try:
-    from wagtail import VERSION as wagtail_version
-except ImportError:
-    #: As of wagtail 1.7 VERSION is located in Wagtail's __init__
-    wagtail_version = (1, 6)
-
+from django import VERSION as django_version
+from wagtail import VERSION as wagtail_version
 from wagtailtrans import WAGTAILTRANS_TEMPLATE_DIR
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -67,6 +63,7 @@ INSTALLED_APPS = [
     'tests._sandbox.search',
 ]
 
+
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -81,6 +78,9 @@ MIDDLEWARE = [
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
     'wagtailtrans.middleware.TranslationMiddleware'
 ]
+
+if django_version < (1, 10):
+    MIDDLEWARE_CLASSES = MIDDLEWARE
 
 ROOT_URLCONF = 'tests._sandbox.urls'
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -22,9 +22,6 @@ class TestWagtailAdminLanguageForm(object):
 
         assert 'is_default' in self.form_class().fields.keys()
 
-        with override_settings(WAGTAILTRANS_LANGUAGES_PER_SITE=True):
-            assert 'is_default' not in self.form_class().fields.keys()
-
     def test_clean_is_default(self):
         language = LanguageFactory(is_default=True)
         form = self.form_class(instance=language, data={

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -108,3 +108,19 @@ class TestAddTranslationView(object):
         view = TranslationView.as_view()
         with pytest.raises(Http404):
             view(rf.post('/'), instance_id=0, language_code='en')
+
+
+@pytest.mark.django_db
+class TestLanguageAdminView(object):
+
+    def setup(self):
+        self.language = language.LanguageFactory()
+
+    def test_response_language_add_view(self, admin_client):
+        response = admin_client.get('/admin/wagtailtrans/language/create/')
+        assert response.status_code == 200
+
+    def test_response_language_edit_view(self, admin_client):
+        response = admin_client.get(
+            '/admin/wagtailtrans/language/edit/%d/' % self.language.pk)
+        assert response.status_code == 200


### PR DESCRIPTION
Their is a issue with WAGTAILTRANS_LANGUAGES_PER_SITE setting, when it is set to True, we then  get a KeyError: u'is_default'. You don't even need to delete the is_default field, when it isn't even added to the FieldPanel, it wont show, The field is a boolean field that is set to false. So when you create a language it will pass without problems.