### PR TITLE
Add tests for Wagtail 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - env: TOXENV=py35-dj110-postgres-wt18
       python: 3.5
 
-      # Wagtail 1.9
+    # Wagtail 1.9
     - env: TOXENV=py27-dj18-postgres-wt19
       python: 2.7
     - env: TOXENV=py34-dj18-postgres-wt19
@@ -44,14 +44,7 @@ matrix:
       python: 3.4
     - env: TOXENV=py35-dj110-postgres-wt110
       python: 3.5
-    - env: TOXENV=py27-dj111-postgres-wt110
-      python: 2.7
-    - env: TOXENV=py34-dj111-postgres-wt110
-      python: 3.4
-    - env: TOXENV=py35-dj111-postgres-wt110
-      python: 3.5
-    - env: TOXENV=py36-dj111-postgres-wt110
-      python: 3.6
+
     
     # Wagtail 1.11
     - env: TOXENV=py27-dj18-postgres-wt111
@@ -73,6 +66,28 @@ matrix:
     - env: TOXENV=py35-dj111-postgres-wt111
       python: 3.5
     - env: TOXENV=py36-dj111-postgres-wt111
+      python: 3.6
+
+    # Wagtail 1.12
+    - env: TOXENV=py27-dj18-postgres-wt112
+      python: 2.7
+    - env: TOXENV=py34-dj18-postgres-wt112
+      python: 3.4
+    - env: TOXENV=py35-dj18-postgres-wt112
+      python: 3.5
+    - env: TOXENV=py27-dj110-postgres-wt112
+      python: 2.7
+    - env: TOXENV=py34-dj110-postgres-wt112
+      python: 3.4
+    - env: TOXENV=py35-dj110-postgres-wt112
+      python: 3.5
+    - env: TOXENV=py27-dj111-postgres-wt112
+      python: 2.7
+    - env: TOXENV=py34-dj111-postgres-wt112
+      python: 3.4
+    - env: TOXENV=py35-dj111-postgres-wt112
+      python: 3.5
+    - env: TOXENV=py36-dj111-postgres-wt112
       python: 3.6
 
     - env: TOXENV=flake8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,11 @@ environment:
   matrix:
     - TOXENV: py27-dj18-mssql-wt18
     - TOXENV: py34-dj110-mssql-wt19
-    - TOXENV: py27-dj111-mssql-wt111
     - TOXENV: py34-dj111-mssql-wt111
-    - TOXENV: py35-dj111-mssql-wt111
-    - TOXENV: py36-dj111-mssql-wt111
+    - TOXENV: py27-dj111-mssql-wt112
+    - TOXENV: py34-dj111-mssql-wt112
+    - TOXENV: py35-dj111-mssql-wt112
+    - TOXENV: py36-dj111-mssql-wt112
 
 matrix:
   fast_finish: true

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist = True
 usedevelop = True
 envlist =
-    py{27,34,35}-dj{18,110}-{postgres,mssql}-wt{18,19,110,111},
-    py{27,34,35,36}-dj111-{postgres,mssql}-wt{110,111},
+    py{27,34,35}-dj{18,110}-{postgres,mssql}-wt{18,19,110,111,112},
+    py{27,34,35,36}-dj111-{postgres,mssql}-wt{111,112},
     flake8
 
 [testenv]
@@ -27,6 +27,7 @@ deps =
     wt19: wagtail>=1.9,<1.10
     wt110: wagtail>=1.10,<1.11
     wt111: wagtail>=1.11,<1.12
+    wt112: wagtail>=1.12,<1.13
 setenv =
     DJANGO_SETTINGS_MODULE=tests._sandbox.settings
     # https://www.appveyor.com/docs/services-databases/#sql-server-2016


### PR DESCRIPTION
- Add Wagtail 1.12 to the testsuite. 
- Trim down Wagtail 1.9 tests.