### PR TITLE
Cleanup for Wagtail 1.12 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,71 +3,6 @@ language: python
 cache: pip
 matrix:
   include:
-    # Wagtail 1.8
-    - env: TOXENV=py27-dj18-postgres-wt18
-      python: 2.7
-    - env: TOXENV=py34-dj18-postgres-wt18
-      python: 3.4
-    - env: TOXENV=py35-dj18-postgres-wt18
-      python: 3.5
-    - env: TOXENV=py27-dj110-postgres-wt18
-      python: 2.7
-    - env: TOXENV=py34-dj110-postgres-wt18
-      python: 3.4
-    - env: TOXENV=py35-dj110-postgres-wt18
-      python: 3.5
-
-    # Wagtail 1.9
-    - env: TOXENV=py27-dj18-postgres-wt19
-      python: 2.7
-    - env: TOXENV=py34-dj18-postgres-wt19
-      python: 3.4
-    - env: TOXENV=py35-dj18-postgres-wt19
-      python: 3.5
-    - env: TOXENV=py27-dj110-postgres-wt19
-      python: 2.7
-    - env: TOXENV=py34-dj110-postgres-wt19
-      python: 3.4
-    - env: TOXENV=py35-dj110-postgres-wt19
-      python: 3.5
-
-    # Wagtail 1.10
-    - env: TOXENV=py27-dj18-postgres-wt110
-      python: 2.7
-    - env: TOXENV=py34-dj18-postgres-wt110
-      python: 3.4
-    - env: TOXENV=py35-dj18-postgres-wt110
-      python: 3.5
-    - env: TOXENV=py27-dj110-postgres-wt110
-      python: 2.7
-    - env: TOXENV=py34-dj110-postgres-wt110
-      python: 3.4
-    - env: TOXENV=py35-dj110-postgres-wt110
-      python: 3.5
-
-    
-    # Wagtail 1.11
-    - env: TOXENV=py27-dj18-postgres-wt111
-      python: 2.7
-    - env: TOXENV=py34-dj18-postgres-wt111
-      python: 3.4
-    - env: TOXENV=py35-dj18-postgres-wt111
-      python: 3.5
-    - env: TOXENV=py27-dj110-postgres-wt111
-      python: 2.7
-    - env: TOXENV=py34-dj110-postgres-wt111
-      python: 3.4
-    - env: TOXENV=py35-dj110-postgres-wt111
-      python: 3.5
-    - env: TOXENV=py27-dj111-postgres-wt111
-      python: 2.7
-    - env: TOXENV=py34-dj111-postgres-wt111
-      python: 3.4
-    - env: TOXENV=py35-dj111-postgres-wt111
-      python: 3.5
-    - env: TOXENV=py36-dj111-postgres-wt111
-      python: 3.6
-
     # Wagtail 1.12
     - env: TOXENV=py27-dj18-postgres-wt112
       python: 2.7
@@ -90,6 +25,7 @@ matrix:
     - env: TOXENV=py36-dj111-postgres-wt112
       python: 3.6
 
+    # Flake 8
     - env: TOXENV=flake8
       python: 2.7
 install:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Changelog
 0.2 (XX-XX-XXXX)
 ------------------
 
-This release drops support for Wagtail versions below 1.12
+ - Dropped support for Wagtail versions earlier than 1.12
+ - Custom ``get_admin_display_title`` method now uses Wagtails ``draft_title``
 
 
 0.1.5 (27-08-2017)

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Requirements
 
  - Python 2.7+
  - Django 1.8+
- - Wagtail 1.8+
+ - Wagtail 1.12+
 
 
 Getting started

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,6 @@ services:
 
 environment:
   matrix:
-    - TOXENV: py27-dj18-mssql-wt18
-    - TOXENV: py34-dj110-mssql-wt19
-    - TOXENV: py34-dj111-mssql-wt111
     - TOXENV: py27-dj111-mssql-wt112
     - TOXENV: py34-dj111-mssql-wt112
     - TOXENV: py35-dj111-mssql-wt112

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -55,26 +55,7 @@ Installation
 .. note::
 
     It relies on ``wagtail.wagtailcore.middleware.SiteMiddleware``, which should come before it.
-    See http://docs.wagtail.io/en/v1.8/getting_started/integrating_into_django.html#settings for more information.
-
-
-4. Optionally, add ``WAGTAILTRANS_TEMPLATE_DIR`` to your ``TEMPLATES[0]['DIRS']``
-
-.. note::
-    As of Wagtail 1.8 ``Page.get_admin_display_title`` is added which doesn't require overriding admin templates anymore, so if you're on Wagtail >= 1.8 you can skip this step.
-
-
-.. code-block:: python
-
-    from wagtailtrans import WAGTAILTRANS_TEMPLATE_DIR
-
-    TEMPLATES = [{
-        # ...
-        'DIRS': [
-            WAGTAILTRANS_TEMPLATE_DIR,
-        ],
-        # ...
-    }]
+    See http://docs.wagtail.io/en/latest/getting_started/integrating_into_django.html#settings for more information.
 
 
 -------------

--- a/docs/source/releases/0.2.rst
+++ b/docs/source/releases/0.2.rst
@@ -11,14 +11,19 @@ Wagtailtrans 0.2 release notes - IN DEVELOPMENT
 What is new
 -----------
 
-
+This release is a new major since it will only support Wagtail 1.12 and up. 
+By dropping support for < 1.11 we are keeping inline with Wagtails own `release schedule <http://docs.wagtail.io/en/v1.12.1/releases/upgrading.html#version-numbers>`_.
 
 Features
 ~~~~~~~~
 
+- Dropped support for Wagtail versions earlier than 1.12
+- Custom ``get_admin_display_title`` method now uses Wagtails ``draft_title``
 
 ------------------------------
 Backwards incompatible changes
 ------------------------------
 
-This release drops support for Wagtail versions below 1.12
+This release drops support for Wagtail versions below 1.12.
+
+- References to ``WAGTAILTRANS_TEMPLATE_DIR`` can be cleaned up since it was a requirement prior to Wagtail 1.8

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from wagtailtrans import get_version # noqa isort:skip
 
 sandbox_require =[
     'Django>=1.8',
-    'Wagtail>=1.8',
+    'Wagtail>=1.12',
     'psycopg2>=2.5.4',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Framework :: Django',
         'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Topic :: Internet :: WWW/HTTP :: Site Management',

--- a/setup.py
+++ b/setup.py
@@ -59,10 +59,12 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Framework :: Django',
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
         'Topic :: Internet :: WWW/HTTP :: Site Management',
     ]
 )

--- a/src/wagtailtrans/__init__.py
+++ b/src/wagtailtrans/__init__.py
@@ -1,5 +1,3 @@
-from os import path
-
 default_app_config = 'wagtailtrans.apps.WagtailTransConfig'
 
 VERSION = (0, 2, 0, 'dev0')

--- a/src/wagtailtrans/__init__.py
+++ b/src/wagtailtrans/__init__.py
@@ -4,8 +4,6 @@ default_app_config = 'wagtailtrans.apps.WagtailTransConfig'
 
 VERSION = (0, 2, 0, 'dev0')
 
-WAGTAILTRANS_TEMPLATE_DIR = path.join(path.dirname(__file__), 'templates')
-
 
 def get_version():
     """Return normalised version string."""

--- a/src/wagtailtrans/models.py
+++ b/src/wagtailtrans/models.py
@@ -171,7 +171,10 @@ class TranslatablePage(Page):
     base_form_class = AdminTranslatablePageForm
 
     def get_admin_display_title(self):
-        return "{} ({})".format(self.title, self.language)
+        return "{} ({})".format(
+            super(TranslatablePage, self).get_admin_display_title(),
+            self.language
+        )
 
     def serve(self, request, *args, **kwargs):
         activate(self.language.code)

--- a/src/wagtailtrans/templatetags/translations_wagtail_admin.py
+++ b/src/wagtailtrans/templatetags/translations_wagtail_admin.py
@@ -1,4 +1,4 @@
-import django
+from django import VERSION as django_version
 from django import template
 
 from wagtailtrans.conf import get_wagtailtrans_setting
@@ -7,7 +7,7 @@ from wagtailtrans.models import TranslatablePage
 register = template.Library()
 
 
-if django.VERSION >= (1, 9):
+if django_version >= (1, 9):
     assignment_tag = register.simple_tag
 else:
     assignment_tag = register.assignment_tag

--- a/src/wagtailtrans/urls/translations.py
+++ b/src/wagtailtrans/urls/translations.py
@@ -1,14 +1,8 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import url
-from wagtail import VERSION as WAGTAIL_VERSION
 
-if WAGTAIL_VERSION < (1, 11):
-    from wagtailtrans.views.translation import (
-        DeprecatedTranslationView as TranslationView
-    )
-else:
-    from wagtailtrans.views.translation import TranslationView
+from wagtailtrans.views.translation import TranslationView
 
 app_name = 'wagtailtrans'
 

--- a/src/wagtailtrans/views/translation.py
+++ b/src/wagtailtrans/views/translation.py
@@ -9,7 +9,7 @@ from wagtailtrans.forms import TranslationForm
 from wagtailtrans.models import Language, TranslatablePage
 
 
-class AbstractTranslationView(CreateView):
+class TranslationView(CreateView):
     model = TranslatablePage
     form_class = TranslationForm
 
@@ -26,11 +26,8 @@ class AbstractTranslationView(CreateView):
         self.language = get_object_or_404(Language, code=language_code)
         self.instance = get_object_or_404(
             TranslatablePage, id=instance_id).specific
-        return super(AbstractTranslationView, self).dispatch(
+        return super(TranslationView, self).dispatch(
             request, *args, **kwargs)
-
-
-class TranslationView(AbstractTranslationView):
 
     def get_form_kwargs(self):
         kwargs = super(TranslationView, self).get_form_kwargs()
@@ -44,25 +41,3 @@ class TranslationView(AbstractTranslationView):
         new_page = self.instance.create_translation(
             self.language, copy_fields=copy_from_canonical, parent=parent)
         return redirect('wagtailadmin_pages:edit', new_page.id)
-
-
-class DeprecatedTranslationView(AbstractTranslationView):
-    """
-    TranslationView prior to Wagtail 1.11
-    """
-    def get(self, request):
-        self.form = self.form_class(
-            instance=self.instance, language=self.language)
-        return self.render_to_response()
-
-    def post(self, request):
-        self.form = self.form_class(
-            request.POST, instance=self.instance, language=self.language)
-        if self.form.is_valid():
-            parent = self.form.cleaned_data['parent_page']
-            copy_from_canonical = self.form.cleaned_data['copy_from_canonical']
-            new_page = self.instance.create_translation(
-                self.language, copy_fields=copy_from_canonical, parent=parent)
-            return redirect('wagtailadmin_pages:edit', new_page.id)
-        else:
-            return self.render_to_response()

--- a/tests/_sandbox/settings/base.py
+++ b/tests/_sandbox/settings/base.py
@@ -13,8 +13,6 @@
 import os
 
 from django import VERSION as django_version
-from wagtail import VERSION as wagtail_version
-from wagtailtrans import WAGTAILTRANS_TEMPLATE_DIR
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -99,9 +97,6 @@ TEMPLATES = [
         },
     },
 ]
-
-if wagtail_version < (1, 8):
-    TEMPLATES[0]['DIRS'].append(WAGTAILTRANS_TEMPLATE_DIR)
 
 WSGI_APPLICATION = 'tests._sandbox.wsgi.application'
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -100,6 +100,15 @@ class TestTranslatablePage(object):
     def test_create(self):
         assert self.canonical_page.language.code == 'en'
 
+    def test_get_admin_display_title(self):
+        en_root = self.canonical_page
+        assert en_root.get_admin_display_title()  == 'en homepage (English)'
+
+        en_root.draft_title = 'en draft example'
+        en_root.save()
+
+        assert en_root.get_admin_display_title()  == 'en draft example (English)'
+
     def test_create_translation(self, languages):
         """Test `create_translation` without copying fields."""
         nl = languages.get(code='nl')

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -3,16 +3,9 @@ import pytest
 from django.db.models import signals
 from django.http import Http404
 from django.test import override_settings
-from wagtail import VERSION as WAGTAIL_VERSION
 
 from wagtailtrans.models import TranslatablePage
-
-if WAGTAIL_VERSION < (1, 11):
-    from wagtailtrans.views.translation import (
-        DeprecatedTranslationView as TranslationView
-    )
-else:
-    from wagtailtrans.views.translation import TranslationView
+from wagtailtrans.views.translation import TranslationView
 
 from tests.factories import language, pages, sites
 
@@ -38,10 +31,7 @@ class TestAddTranslationView(object):
         response = view.dispatch(
             request, instance_id=self.last_page.pk, language_code='fr')
 
-        if WAGTAIL_VERSION < (1, 11):
-            parent_page_qs = view.form['parent_page'].field.queryset
-        else:
-            parent_page_qs = view.get_form().fields['parent_page'].queryset
+        parent_page_qs = view.get_form().fields['parent_page'].queryset
 
         assert response.status_code == 200
         assert parent_page_qs.count() == 1
@@ -54,10 +44,7 @@ class TestAddTranslationView(object):
         response = view.dispatch(
             request, instance_id=self.last_page.pk, language_code='fr')
 
-        if WAGTAIL_VERSION < (1, 11):
-            parent_page_qs = view.form['parent_page'].field.queryset
-        else:
-            parent_page_qs = view.get_form().fields['parent_page'].queryset
+        parent_page_qs = view.get_form().fields['parent_page'].queryset
 
         # We have a french page to add our new translated page to
         assert parent_page_qs.count() == 1
@@ -98,10 +85,7 @@ class TestAddTranslationView(object):
                 language_code=self.default_language.code)
 
         assert response.status_code == 200
-        if WAGTAIL_VERSION < (1, 11):
-            assert not view.form.is_valid()
-        else:
-            assert not view.get_form().is_valid()
+        assert not view.get_form().is_valid()
 
     def test_post_404(self, rf):
         """It should raise a 404 when a wrong page_pk is given."""

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist = True
 usedevelop = True
 envlist =
-    py{27,34,35}-dj{18,110}-{postgres,mssql}-wt{18,19,110,111,112},
-    py{27,34,35,36}-dj111-{postgres,mssql}-wt{111,112},
+    py{27,34,35}-dj{18,110}-{postgres,mssql}-wt{112},
+    py{27,34,35,36}-dj111-{postgres,mssql}-wt{112},
     flake8
 
 [testenv]
@@ -22,11 +22,6 @@ deps =
     dj18-mssql: django-pyodbc-azure==1.8.17.0
     dj110-mssql: django-pyodbc-azure==1.10.4.0
     dj111-mssql: django-pyodbc-azure==1.11.0.0
-    wt17: wagtail>=1.7,<1.8
-    wt18: wagtail>=1.8,<1.9
-    wt19: wagtail>=1.9,<1.10
-    wt110: wagtail>=1.10,<1.11
-    wt111: wagtail>=1.11,<1.12
     wt112: wagtail>=1.12,<1.13
 setenv =
     DJANGO_SETTINGS_MODULE=tests._sandbox.settings


### PR DESCRIPTION
- [x] Remove earlier Wagtail versions from CI suite
- [x] Cleanup `DeprecatedTranslationView`
- [x] Implement usage of `draft_title` within [`get_admin_display_title`](http://docs.wagtail.io/en/v1.12.1/releases/1.12.html#custom-get-admin-display-title-methods-should-use-draft-title)
- [x] Add test for `get_admin_display_title`