### PR TITLE
Remember language preference in cookie

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -21,3 +21,4 @@ Contributors
  - Oktay Altay
  - Md Arifin Ibne Matin
  - Nazmul Hasan
+ - Michael van de Waeter

--- a/src/wagtailtrans/middleware.py
+++ b/src/wagtailtrans/middleware.py
@@ -1,17 +1,46 @@
 from django.conf import settings
 from django.utils import translation
 from django.utils.deprecation import MiddlewareMixin
+from django.utils.translation import LANGUAGE_SESSION_KEY, check_for_language, get_language_from_path
+from django.utils.translation.trans_real import get_languages, get_supported_language_variant
 
 from .models import Language
 from .sites import get_languages_for_site
+
+
+def get_language_from_request(request):
+    """
+    Analyze the request to find what language the user wants the system to
+    show. Only languages listed in settings.LANGUAGES are taken into account.
+    If the user requests a sublanguage where we have a main language, we send
+    out the main language.
+
+    The URL path prefix will be checked for a language code.
+    """
+    lang_code = get_language_from_path(request.path_info)
+    if lang_code is not None:
+        return lang_code
+
+    supported_lang_codes = get_languages()
+
+    if hasattr(request, 'session'):
+        lang_code = request.session.get(LANGUAGE_SESSION_KEY)
+        if lang_code in supported_lang_codes and lang_code is not None and check_for_language(lang_code):
+            return lang_code
+
+    lang_code = request.COOKIES.get(settings.LANGUAGE_COOKIE_NAME)
+
+    try:
+        return get_supported_language_variant(lang_code)
+    except LookupError:
+        return None
 
 
 class TranslationMiddleware(MiddlewareMixin):
     def process_request(self, request):
         active_language = None
 
-        language_from_request = translation.get_language_from_request(
-            request, check_path=True)
+        language_from_request = get_language_from_request(request)
         requested_languages = request.META.get('HTTP_ACCEPT_LANGUAGE')
         if language_from_request:
             active_language = language_from_request


### PR DESCRIPTION
This PR should add a preferred language cookie in the browser on each request.
The checking for a language is now as follows:
1. path
2. cookie
3. browser accept headers
4. default site language from wagtailtrans
5. default language in settings