### PR TITLE
Add a HIDE_TRANSLATION_TREES setting with an edit in button

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -5,7 +5,10 @@
 Settings
 ========
 
-There are a few settings which can be used to configure wagtailtrans to suit your needs, these settings need to be configured in your django settings module. All wagtailtrans settings are prefixed with ``WAGTAILTRANS_`` to avoid conflicts with other packages used.
+There are a few settings which can be used to configure wagtailtrans to suit
+your needs, these settings need to be configured in your django settings module.
+All wagtailtrans settings are prefixed with ``WAGTAILTRANS_`` to avoid conflicts
+with other packages used.
 
 
 ``WAGTAILTRANS_SYNC_TREE``
@@ -27,4 +30,17 @@ If set to ``False`` wagtailtrans will work with ``Freeform`` trees.
 
 :Default: ``False``
 
-If set to ``True`` wagtailtrans will allow you to define a default language and additional languages per site. This is mostly used in a ``multi site`` setup and allowes you to define the languages per site, this way they can differ for all available sites.
+If set to ``True`` wagtailtrans will allow you to define a default language and
+additional languages per site. This is mostly used in a ``multi site`` setup and
+allowes you to define the languages per site, this way they can differ for all
+available sites.
+
+
+``WAGTAILTRANS_HIDE_TRANSLATION_TREES``
+---------------------------------------
+
+:Default: ``False``
+
+If set to ``True`` the CMS user will only see the tree of the canonical
+language, with an ``edit in`` button where they can choose the language to edit
+the page in.

--- a/src/wagtailtrans/conf.py
+++ b/src/wagtailtrans/conf.py
@@ -3,6 +3,7 @@ from django.conf import settings
 DEFAULT_SETTINGS = {
     'SYNC_TREE': True,
     'LANGUAGES_PER_SITE': False,
+    'HIDE_TRANSLATION_TREES': False,
 }
 
 

--- a/src/wagtailtrans/wagtail_hooks.py
+++ b/src/wagtailtrans/wagtail_hooks.py
@@ -90,6 +90,11 @@ if not get_wagtailtrans_setting('SYNC_TREE'):
 
 @hooks.register('construct_explorer_page_queryset')
 def hide_non_canonical_languages(parent_page, pages, request):
+    """Hide translations when WAGTAILTRANS_HIDE_TRANSLATION_TREES=True.
+
+    This allows the user to only see the canonical language in the admin.
+
+    """
     if parent_page.depth > 1 and get_wagtailtrans_setting('HIDE_TRANSLATION_TREES'):
         return pages.filter(
             pk__in=(
@@ -103,6 +108,14 @@ def hide_non_canonical_languages(parent_page, pages, request):
 
 @hooks.register('register_page_listing_buttons')
 def edit_in_language_button(page, page_perms, is_parent=False):
+    """Add ``Edit in`` button to the page explorer.
+
+    When hiding all other translation except the canonical language, which is
+    done via ``WAGTAILTRANS_HIDE_TRANSLATION_TREES`` this will add an button to
+    allow the user to select a other language to edit, which provides a more
+    clear interface to work in.
+
+    """
     if not hasattr(page, 'language'):
         return
 
@@ -118,6 +131,13 @@ def edit_in_language_button(page, page_perms, is_parent=False):
 
 @hooks.register('wagtailtrans_dropdown_edit_hook')
 def edit_in_language_items(page, page_perms, is_parent=False):
+    """Add all other languages in the ``Edit in`` dropdown.
+
+    All languages other than the canonical language are listed as dropdown
+    options which allows the user to click on them and edit the page in the
+    language they prefer.
+
+    """
     other_languages = (
         page.specific
         .get_translations(only_live=False)


### PR DESCRIPTION
This allows the CMS editor to only see the tree of the canonical
language but also lets the user edit the page in the different
laganguages.