### PR TITLE
Add ?next= to edit url to redirect back to the right tree after edit.

### DIFF
--- a/src/wagtailtrans/wagtail_hooks.py
+++ b/src/wagtailtrans/wagtail_hooks.py
@@ -147,8 +147,12 @@ def edit_in_language_items(page, page_perms, is_parent=False):
     )
 
     for prio, language_page in enumerate(other_languages):
+        edit_url = reverse('wagtailadmin_pages:edit', args=(language_page.pk,))
+        return_page = language_page.canonical_page or language_page
+        next_url = reverse('wagtailadmin_explore', args=(return_page.get_parent().pk,))
+
         yield widgets.Button(
             force_text(language_page.language),
-            reverse('wagtailadmin_pages:edit', args=(language_page.pk,)),
+            f"{edit_url}?next={next_url}",
             priority=prio,
         )


### PR DESCRIPTION
At the moment the user returns to explore view of the parent page, when the non-canonical tree is hidden, this doesn't display the child pages, which makes it hard to edit other child pages.

By adding ``?next=/url/to/parent-canonical`` the user gets redirected to to canonical page of the parent, which is the expecting behavior and allows the user to edit pages again in different languages with the ``edit in`` dropdown.